### PR TITLE
A fix, and MRE Grenade compat

### DIFF
--- a/classes/soldier.config
+++ b/classes/soldier.config
@@ -221,7 +221,7 @@
 			"type" : "Head",
 			"name" : "soldiermre",
 			"level" : 4,
-			"text" : "Press [Shift] + [F] to eat an MRE, gaining a bit of food and all your energy: this has a 90 second cooldown. While this cooldown is active, you gain slight health regen, but your overall speed is decreased.\nIf you have a Grenade equipped in your Right Hand, press [F] to toss a weaker, generated copy towards your cursor for only 20 Energy: this has a 2 second cooldown."
+			"text" : "Press [Shift] + [F] to eat an MRE, gaining a bit of food and all your energy: this has a 90 second cooldown. While this cooldown is active, you gain slight health regen, but your overall speed is decreased.\nIf you have a Grenade equipped in your Left Hand (or a 2-handed grenade), press [F] to toss a weaker, generated copy towards your cursor for only 20 Energy: this has a 2 second cooldown."
 		},
 		{
 			"title" : "Marksman",

--- a/specs/cannoneer.config
+++ b/specs/cannoneer.config
@@ -100,7 +100,7 @@
 					"amount" : 1.2,
 					"anyHand" : true
 				},
-				"rpgffsgrenade" : {
+				"rpgffsgl" : {
 					"amount" : 1.2,
 					"anyHand" : true
 				}

--- a/tech/soldiertech/soldiermre/soldiermre.lua
+++ b/tech/soldiertech/soldiermre/soldiermre.lua
@@ -42,7 +42,7 @@ function lobGrenade()
       self.grenadeConfig.power = grenade.power / 2 or 0
       self.grenadeConfig.speed = grenade.speed or 0
       world.spawnProjectile(grenade.name or handItem, mcontroller.position(), self.id, world.distance(tech.aimPosition(), mcontroller.position()), false, self.grenadeConfig)
-      self.grenadeCooldownTimer = 5
+      self.grenadeCooldownTimer = 2
     end
   end
 end

--- a/tech/soldiertech/soldiermre/soldiermre.lua
+++ b/tech/soldiertech/soldiermre/soldiermre.lua
@@ -42,7 +42,7 @@ function lobGrenade()
       self.grenadeConfig.power = grenade.power / 2 or 0
       self.grenadeConfig.speed = grenade.speed or 0
       world.spawnProjectile(grenade.name or handItem, mcontroller.position(), self.id, world.distance(tech.aimPosition(), mcontroller.position()), false, self.grenadeConfig)
-      self.grenadeCooldownTimer = 2
+      self.grenadeCooldownTimer = 5
     end
   end
 end

--- a/tech/soldiertech/soldiermre/soldiermre.lua
+++ b/tech/soldiertech/soldiermre/soldiermre.lua
@@ -35,7 +35,7 @@ function eat()
 end
 
 function lobGrenade()
-  local handItem = world.entityHandItem(self.id, "alt")
+  local handItem = world.entityHandItem(self.id, "primary")
   if handItem then
     local grenade = self.validGrenades[handItem]
     if grenade and status.overConsumeResource("energy", 20) then

--- a/tech/soldiertech/soldiermre/soldiermre.tech
+++ b/tech/soldiertech/soldiermre/soldiermre.tech
@@ -58,6 +58,170 @@
     "ivrpgstungrenade" : {
       "speed" : 50,
       "power" : 1
+    },
+    "ffs_frag_1" : {
+      "speed" : 50,
+      "power" : 63
+    },
+    "ffs_frag_rgo_1" : {
+      "speed" : 50,
+      "power" : 63
+    },
+    "ffs_molotov" : {
+      "name" : "ffs_molotov_2",
+      "speed" : 25,
+      "power" : 1
+    },
+    "ffs_smoke" : {
+      "name" : "ffs_smoke",
+      "speed" : 25,
+      "power" : 1
+    },
+    "ffs_smoke_airsupport" : {
+      "name" : "ffs_smoke_airsupport_start",
+      "speed" : 25,
+      "power" : 1
+    },
+    "ue_molotovbomb" : {
+      "speed" : 31.5,
+      "power" : 17.5
+    },
+    "ue_handheldtorpedo" : {
+      "speed" : 1,
+      "power" : 30.2
+    },
+    "ue_m1883smokegrenade" : {
+      "speed" : 50,
+      "power" : 1
+    },
+    "ue_no775" : {
+      "speed" : 29.8,
+      "power" : 100.1
+    },
+    "ue_pineapplegrenade" : {
+      "speed" : 32.5,
+      "power" : 17.5
+    },
+    "ue_rebelfrag" : {
+      "speed" : 46.5,
+      "power" : 27.5
+    },
+    "ue_rsf1grenade" : {
+      "speed" : 35,
+      "power" : 13.5
+    },
+    "akkimari-nailbomb" : {
+      "name" : "akkimarinailbomb",
+      "speed" : 50,
+      "power" : 20
+    },
+    "akkimari-vaashbomb" : {
+      "name" : "akkimarivaashbomb",
+      "speed" : 50,
+      "power" : 15
+    },
+    "allianceexplosivecharge" : {
+      "speed" : 15,
+      "power" : 50
+    },
+    "alliancethrowablegrenade" : {
+      "speed" : 40,
+      "power" : 40
+    },
+    "avikanexplosive" : {
+      "speed" : 15,
+      "power" : 50
+    },
+    "avikansandbomb" : {
+      "speed" : 40,
+      "power" : 40
+    },
+    "avikanthrowablegrenade" : {
+      "speed" : 40,
+      "power" : 40
+    },
+    "trinkfrostgrenade" : {
+      "speed" : 40,
+      "power" : 20
+    },
+    "fu_beebriefcase" : {
+      "speed" : 40,
+      "power" : 1.5
+    },
+    "bellamortecore" : {
+      "name" : "bellamortebomb",
+      "speed" : 50,
+      "power" : 14
+    },
+    "antigravgrenade" : {
+      "name" : "antigravbomb",
+      "speed" : 35,
+      "power" : 0
+    },
+    "gravgrenade" : {
+      "name" : "gravbomb",
+      "speed" : 35,
+      "power" : 0
+    },
+    "pekkitfreeze_freezegrenade" : {
+      "name" : "gravbomb",
+      "speed" : 45,
+      "power" : 1
+    },
+    "pekkitfreeze_freezegrenade" : {
+      "name" : "gravbomb",
+      "speed" : 45,
+      "power" : 1
+    },
+    "fuwolfcase" : {
+      "speed" : 40,
+      "power" : 1.5
+    },
+    "chilibomb" : {
+      "speed" : 45,
+      "power" : 10,
+      "level" : 2
+    },
+    "ignuschili" : {
+      "name" : "ignus",
+      "speed" : 45,
+      "power" : 9,
+      "level" : 2
+    },
+    "ignuschili" : {
+      "name" : "ignus",
+      "speed" : 45,
+      "power" : 9,
+      "level" : 2
+    },
+    "ignuschili2" : {
+      "name" : "ignus2",
+      "speed" : 65,
+      "power" : 11,
+      "level" : 4
+    },
+    "madnessbomb" : {
+      "name" : "madnessbombteam",
+      "speed" : 45,
+      "power" : 10,
+      "level" : 2
+    },
+    "nailbomb" : {
+      "name" : "nailbombthrown",
+      "speed" : 45,
+      "power" : 5
+    },
+    "radienbulb" : {
+      "name" : "radienbulbthrown",
+      "speed" : 45,
+      "power" : 3,
+      "level" : 2
+    },
+    "shockshroom" : {
+      "name" : "shroomshock",
+      "speed" : 45,
+      "power" : 8,
+      "level" : 3
     }
   }
 }

--- a/tech/soldiertech/soldiermre/soldiermre.tech
+++ b/tech/soldiertech/soldiermre/soldiermre.tech
@@ -222,6 +222,11 @@
       "speed" : 45,
       "power" : 8,
       "level" : 3
+    },
+    "ancientgrenade" : {
+      "name" : "ancientgrenadethrown",
+      "speed" : 25,
+      "power" : 40
     }
   }
 }

--- a/tech/soldiertech/soldiermre/soldiermre.tech
+++ b/tech/soldiertech/soldiermre/soldiermre.tech
@@ -69,17 +69,17 @@
     },
     "ffs_molotov" : {
       "name" : "ffs_molotov_2",
-      "speed" : 25,
+      "speed" : 50,
       "power" : 1
     },
     "ffs_smoke" : {
       "name" : "ffs_smoke",
-      "speed" : 25,
+      "speed" : 50,
       "power" : 1
     },
     "ffs_smoke_airsupport" : {
       "name" : "ffs_smoke_airsupport_start",
-      "speed" : 25,
+      "speed" : 50,
       "power" : 1
     },
     "ue_molotovbomb" : {


### PR DESCRIPTION
* Fixed Cannoneer FFS Typo.

* MRE ability now works with grenades from:
- FFS
- US.E
- Elithian Races
- Frackin (Note: does not count Particle, Neutron, or Hydrogen bombs.)