### PR TITLE
Specialization Update

### DIFF
--- a/ivrpgStats.config
+++ b/ivrpgStats.config
@@ -120,6 +120,18 @@
 			]
 		},
 		{
+			"text" : "(GiC) Increases Bleed Resist.",
+			"type" : "stat",
+			"apply" : [
+				{
+					"type" : "status",
+					"stat" : "bleedResistance",
+					"amountType" : "amount",
+					"amount" : 0.02
+				}
+			]
+		},		
+		{
 			"text" : "^green;Starting From 20 Vitality:^reset;\nClassic Mode penalty for Max Health and Food Delta halved.\nSpecialization penalty for Max Health and Food Delta halved.",
 			"type" : "classic",
 			"apply" : [
@@ -299,6 +311,42 @@
 				{
 					"type" : "status",
 					"stat" : "radioactiveResistance",
+					"amountType" : "amount",
+					"amount" : 0.005
+				}
+			]
+		},
+		{
+			"text" : "(GiC) Increases melee and arms resistances.",
+			"type" : "stat",
+			"apply" : [
+				{
+					"type" : "status",
+					"stat" : "ews_meleeResistance",
+					"amountType" : "amount",
+					"amount" : 0.01
+				},
+				{
+					"type" : "status",
+					"stat" : "ews_smallarmsResistance",
+					"amountType" : "amount",
+					"amount" : 0.01
+				},
+				{
+					"type" : "status",
+					"stat" : "ews_heavyarmsResistance",
+					"amountType" : "amount",
+					"amount" : 0.005
+				},
+				{
+					"type" : "status",
+					"stat" : "ews_explosiveResistance",
+					"amountType" : "amount",
+					"amount" : 0.005
+				},
+				{
+					"type" : "status",
+					"stat" : "ews_antitankResistance",
 					"amountType" : "amount",
 					"amount" : 0.005
 				}

--- a/ivrpg_specs/adept.config
+++ b/ivrpg_specs/adept.config
@@ -115,11 +115,19 @@
 			]
 		},
 		{
-			"text" : "115% Base Power with Wands: Scales with Dex.",
+			"text" : "115% Base Power with Wands and Sat Batons: Scales with Dex.",
 			"textType" : "benefit",
 			"type" : "weapon",
 			"apply" : {
 				"wand" : {
+					"amount" : 1.15,
+					"anyHand" : true,
+					"allowSecond" : true,
+					"scaling" : {
+						"dexterity" : 0.01
+					}
+				},
+				"magebaton" : {
 					"amount" : 1.15,
 					"anyHand" : true,
 					"allowSecond" : true,

--- a/ivrpg_specs/adept.config
+++ b/ivrpg_specs/adept.config
@@ -11,10 +11,19 @@
 	"classic" : [
 		{
 			"type" : "enable",
-			"text" : "Can Wield Wands.",
+			"text" : "Can Wield Wands and Saturn Batons.",
 			"apply" : {
 				"wand" : {
 					"with" : [
+						"wand",
+						"magebaton",
+						"melee"
+					],
+					"allowAlone" : true
+				},
+				"magebaton" : {
+					"with" : [
+						"magebaton",
 						"wand",
 						"melee"
 					],

--- a/ivrpg_specs/battlemage.config
+++ b/ivrpg_specs/battlemage.config
@@ -18,10 +18,13 @@
 		},
 		{
 			"type" : "disable",
-			"text" : "Cannot use Wands.",
+			"text" : "Cannot use Wands or Saturn Batons.",
 			"textColor" : "red",
 			"apply" : {
 				"wand" : {
+					"all" : true
+				},
+				"magebaton" : {
 					"all" : true
 				}
 			}

--- a/ivrpg_specs/elementress.config
+++ b/ivrpg_specs/elementress.config
@@ -16,7 +16,24 @@
 					"all" : true
 				}
 			}
+		},
+		{
+			"type" : "enable",
+			"text" : "can use Nova/Super Nova/Primed Nova.",
+			"textColor" : "green",
+			"apply" : {
+				"wizardnovastaff" : {
+					"named" : true
+				},
+				"wizardnovastaff2" : {
+					"named" : true
+				}
+				"wizardnovastaff3" : {
+					"named" : true
+				}
+			}
 		}
+		
 	],
 	"effects" : [
 		{
@@ -93,11 +110,16 @@
 			]
 		},
 		{
-			"text" : "120% Base Power with Wands and Daggers.",
+			"text" : "120% Base Power with Wands, Saturn Batons, and Daggers.",
 			"textType" : "benefit",
 			"type" : "weapon",
 			"apply" : {
 				"wand" : {
+					"amount" : 1.2,
+					"anyHand" : true,
+					"allowSecond" : true
+				},
+				"magebaton" : {
 					"amount" : 1.2,
 					"anyHand" : true,
 					"allowSecond" : true

--- a/ivrpg_specs/elementress.config
+++ b/ivrpg_specs/elementress.config
@@ -27,7 +27,7 @@
 				},
 				"wizardnovastaff2" : {
 					"named" : true
-				}
+				},
 				"wizardnovastaff3" : {
 					"named" : true
 				}

--- a/ivrpg_specs/paladin.config
+++ b/ivrpg_specs/paladin.config
@@ -9,9 +9,14 @@
 	"classic" : [
 		{
 			"type" : "enable",
-			"text" : "Can use Wands.",
+			"text" : "Can use Wands or Saturn Batons.",
 			"apply" : {
 				"wand" : {
+					"without" : [
+						"weapon"
+					]
+				},
+				"magebaton" : {
 					"without" : [
 						"weapon"
 					]

--- a/ivrpg_specs/technomancer.config
+++ b/ivrpg_specs/technomancer.config
@@ -43,7 +43,7 @@
 	"classic" : [
 		{
 			"type" : "enable",
-			"text" : "Can Dual-Wield Ranged Weapons and Wands.",
+			"text" : "Can Dual-Wield Ranged Weapons and  Wands/Batons.",
 			"apply" : {
 				"ranged" : {
 					"with" : [
@@ -55,6 +55,12 @@
 				"wand" : {
 					"with" : [
 						"wand"
+					],
+					"allowAlone" : true
+				},
+				"magebaton" : {
+					"with" : [
+						"magebaton"
 					],
 					"allowAlone" : true
 				}

--- a/ivrpg_specs/warlock.config
+++ b/ivrpg_specs/warlock.config
@@ -28,10 +28,13 @@
 	"classic" : [
 		{
 			"type" : "disable",
-			"text" : "Cannot use Wands.",
+			"text" : "Cannot use Wands or Saturn Batons.",
 			"textColor" : "red",
 			"apply" : {
 				"wand" : {
+					"all" : true
+				},
+				"magebaton" : {
 					"all" : true
 				}
 			}

--- a/npcs/base/gic_base.npctype.patch
+++ b/npcs/base/gic_base.npctype.patch
@@ -1,0 +1,3 @@
+[
+{ "op" : "add", "path" : "/scripts/-", "value" : "/npcs/ivrpgnpc.lua" }
+]

--- a/professions/alchemist.config
+++ b/professions/alchemist.config
@@ -6,9 +6,12 @@
 	"classic" : [
 		{
 			"type" : "enable",
-			"text" : "Can use Wands and Magic Orbs.",
+			"text" : "Can use Wands, Sat Batons, and Magic Orbs.",
 			"apply" : {
 				"wand" : {
+					"onlyWithCorrectWeapons" : true
+				},
+				"magebaton" : {
 					"onlyWithCorrectWeapons" : true
 				},
 				"magicorb" : {

--- a/scripts/ivrpgstart.lua
+++ b/scripts/ivrpgstart.lua
@@ -294,7 +294,7 @@ function updateProfessionEffects(dt)
   self.rpg_jewelerExperience = (proftype == 9) and pPassive
   if not pPassive then return end
   if proftype == 1 then
-    if status.resource("health") / status.stat("maxHealth") < 0.25 and not hasEphemeralStats(status.activeUniqueStatusEffectSummary(), {"bandageheal","salveheal","nanowrapheal","medkitheal"}) then
+    if status.resource("health") / status.stat("maxHealth") < 0.25 and not hasEphemeralStats(status.activeUniqueStatusEffectSummary(), {"bandageheal","salveheal","nanowrapheal","medkitheal","ffs_heal_stimpak_1","ffs_heal_stimpak_2","ffs_heal_stimpak_3","ffs_heal_stimpak_4","ffs_heal_morphine","ffs_heal_dressing","knightfall_medkit","knightfall_medicalgauze","heal_tier6","heal_tier7","heal_long","heal_long2","heal_long3","heal_long4","honeysilkheal","mutaviskheal"}) then
       local healthItems = {
       	{item = "ffs_stimpak_4", duration = 2},    
       	{item = "ffs_stimpak_3", duration = 2},    

--- a/scripts/ivrpgstart.lua
+++ b/scripts/ivrpgstart.lua
@@ -296,9 +296,25 @@ function updateProfessionEffects(dt)
   if proftype == 1 then
     if status.resource("health") / status.stat("maxHealth") < 0.25 and not hasEphemeralStats(status.activeUniqueStatusEffectSummary(), {"bandageheal","salveheal","nanowrapheal","medkitheal"}) then
       local healthItems = {
+      	{item = "ffs_stimpak_4", duration = 2},    
+      	{item = "ffs_stimpak_3", duration = 2},    
+      	{item = "knightfall_medkit", duration = 2},
+      	{item = "perfectelygenericmedkit", duration = 10},
+      	{item = "medkit4", duration = 10},
+      	{item = "medkit3", duration = 10},    
       	{item = "nanowrap", duration = 1},
+      	{item = "ffs_stimpak_2", duration = 2},    
+      	{item = "ffs_stimpak_1", duration = 2},        
+      	{item = "mutaviskbandage", duration = 1},
+      	{item = "genesiberry", duration = 2},        
+      	{item = "floralytcandy", duration = 2},      
+      	{item = "ffs_dressingkit", duration = 1}, 
       	{item = "bandage", duration = 1}, 
+      	{item = "knightfall_medicalgauze", duration = 5},    
+      	{item = "medkit2", duration = 10},
+      	{item = "fuhoneysilkbandage", duration = 20},
       	{item = "medkit", duration = 10},
+      	{item = "ffs_morphine", duration = 600},        
       	{item = "salve", duration = 10}
       }
       for _,v in ipairs(healthItems) do

--- a/scripts/ivrpgstart.lua
+++ b/scripts/ivrpgstart.lua
@@ -294,27 +294,11 @@ function updateProfessionEffects(dt)
   self.rpg_jewelerExperience = (proftype == 9) and pPassive
   if not pPassive then return end
   if proftype == 1 then
-    if status.resource("health") / status.stat("maxHealth") < 0.25 and not hasEphemeralStats(status.activeUniqueStatusEffectSummary(), {"bandageheal","salveheal","nanowrapheal","medkitheal","ffs_heal_stimpak_1","ffs_heal_stimpak_2","ffs_heal_stimpak_3","ffs_heal_stimpak_4","ffs_heal_morphine","ffs_heal_dressing","knightfall_medkit","knightfall_medicalgauze","heal_tier6","heal_tier7","heal_long","heal_long2","heal_long3","heal_long4","honeysilkheal","mutaviskheal"}) then
+    if status.resource("health") / status.stat("maxHealth") < 0.25 and not hasEphemeralStats(status.activeUniqueStatusEffectSummary(), {"bandageheal","salveheal","nanowrapheal","medkitheal"}) then
       local healthItems = {
-      	{item = "ffs_stimpak_4", duration = 2},    
-      	{item = "ffs_stimpak_3", duration = 2},    
-      	{item = "knightfall_medkit", duration = 2},
-      	{item = "perfectelygenericmedkit", duration = 10},
-      	{item = "medkit4", duration = 10},
-      	{item = "medkit3", duration = 10},    
       	{item = "nanowrap", duration = 1},
-      	{item = "ffs_stimpak_2", duration = 2},    
-      	{item = "ffs_stimpak_1", duration = 2},        
-      	{item = "mutaviskbandage", duration = 1},
-      	{item = "genesiberry", duration = 2},        
-      	{item = "floralytcandy", duration = 2},      
-      	{item = "ffs_dressingkit", duration = 1}, 
       	{item = "bandage", duration = 1}, 
-      	{item = "knightfall_medicalgauze", duration = 5},    
-      	{item = "medkit2", duration = 10},
-      	{item = "fuhoneysilkbandage", duration = 20},
       	{item = "medkit", duration = 10},
-      	{item = "ffs_morphine", duration = 600},        
       	{item = "salve", duration = 10}
       }
       for _,v in ipairs(healthItems) do

--- a/stagehands/coordinator.stagehand.patch
+++ b/stagehands/coordinator.stagehand.patch
@@ -1,0 +1,496 @@
+[
+  //Class Weapons
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/knightaegissword",
+    "value": {
+      "minRange": 3,
+      "maxRange": 6
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/knightaegissword2",
+    "value": {
+      "minRange": 4,
+      "maxRange": 6
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/knightaegissword3",
+    "value": {
+      "minRange": 4,
+      "maxRange": 6
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/knightaegissword4",
+    "value": {
+      "minRange": 4,
+      "maxRange": 6
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/aethertanto1",
+    "value": {
+      "minRange": 1.25,
+      "maxRange": 4
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/aethertanto2",
+    "value": {
+      "minRange": 1.25,
+      "maxRange": 4
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/aethertanto3",
+    "value": {
+      "minRange": 1.25,
+      "maxRange": 4
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/roguesiphonclaw",
+    "value": {
+      "minRange": 0.5,
+      "maxRange": 3.5
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/roguesiphonclaw2s",
+    "value": {
+      "minRange": 0.5,
+      "maxRange": 3.5
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/roguesiphonclaw2v",
+    "value": {
+      "minRange": 0.5,
+      "maxRange": 3.5
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/roguesiphonclaw3e",
+    "value": {
+      "minRange": 0.5,
+      "maxRange": 3.5
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/roguesiphonclaw3s",
+    "value": {
+      "minRange": 0.5,
+      "maxRange": 3.5
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/roguesiphonclaw3v",
+    "value": {
+      "minRange": 0.5,
+      "maxRange": 3.5
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/soldierversagun", //they can only use it in shotgun mode, so it gets a range reduction.
+    "value": {
+      "minRange": 4.5,
+      "maxRange": 15,
+      "forceMoveRange": 12
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/soldierversagun2", //they typically charge it, so I'll treat it as a sniper.
+    "value": {
+      "minRange": 10,
+      "maxRange": 75,
+      "forceMoveRange": 70
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/soldierversagun3", //ditto.
+    "value": {
+      "minRange": 10,
+      "maxRange": 75,
+      "forceMoveRange": 70
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/wizardnovastaff", //they cannot use this normally, but FU and Suppers both allow you to use wands and staffs, so it's included.
+    "value": {
+      "minRange": 15,
+      "maxRange": 30,
+      "forceMoveRange": 27
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/wizardnovastaff2", //they cannot use this normally, but FU and Suppers both allow you to use wands and staffs, so it's included.
+    "value": {
+      "minRange": 18,
+      "maxRange": 35,
+      "forceMoveRange": 32
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/wizardnovastaff3", //they cannot use this normally, but FU and Suppers both allow you to use wands and staffs, so it's included.
+    "value": {
+      "minRange": 20,
+      "maxRange": 40,
+      "forceMoveRange": 37
+    }
+  },
+  //Specialization Weapons  
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwphaseshift", //they cannot use this normally, but FU and Suppers both allow you to use wands and staffs, so it's included.
+    "value": {
+      "minRange": 5,
+      "maxRange": 10,
+      "forceMoveRange": 9
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwheartstring", 
+    "value": {
+      "minRange": 0.5,
+      "maxRange": 2
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwsolstice", 
+    "value": {
+      "minRange": 1.5,
+      "maxRange": 6
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwmurderstick", // they won't use the hammer part of it.
+    "value": {
+      "minRange": 6,
+      "maxRange": 15,
+      "forceMoveRange": 12
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwmurderstick", // they won't use the hammer part of it.
+    "value": {
+      "minRange": 6,
+      "maxRange": 15
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwoutburst", // this weapon has very little wiggleroom to work with.
+    "value": {
+      "minRange": 16,
+      "maxRange": 17,
+      "forceMoveRange": 16.5
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwstormhowl", 
+    "value": {
+      "minRange": 1.5,
+      "maxRange": 6
+    }
+  },
+  //Skipping Flag and Arquebus as they are unusable by NPCs.
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwoathkeeper", 
+    "value": {
+      "minRange": 3.5,
+      "maxRange": 6
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwheartless", 
+    "value": {
+      "minRange": 3.5,
+      "maxRange": 6
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwlotus",
+    "value": {
+      "minRange": 10,
+      "maxRange": 75,
+      "forceMoveRange": 70
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwdragonsbane", 
+    "value": {
+      "minRange": 4,
+      "maxRange": 11
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgweclipse",
+    "value": {
+      "minRange": 12,
+      "maxRange": 20,
+      "forceMoveRange": 17
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwchrysantha", 
+    "value": {
+      "minRange": 5,
+      "maxRange": 32
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwmida",
+    "value": {
+      "minRange": 20,
+      "maxRange": 50,
+      "forceMoveRange": 45
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwcleavingmeteor", 
+    "value": {
+      "minRange": 2,
+      "maxRange": 7
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwluxuria", 
+    "value": {
+      "minRange": 0.5,
+      "maxRange": 4.5
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwwrench", 
+    "value": {
+      "minRange": 0.5,
+      "maxRange": 4.5
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwexmechina",
+    "value": {
+      "minRange": 20,
+      "maxRange": 65,
+      "forceMoveRange": 60
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwshredder",
+    "value": {
+      "minRange": 10,
+      "maxRange": 40,
+      "forceMoveRange": 35
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwforusall", 
+    "value": {
+      "minRange": 3,
+      "maxRange": 6
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwbreathless",
+    "value": {
+      "minRange": 10,
+      "maxRange": 75,
+      "forceMoveRange": 70
+    }
+  },
+  // Skipping True Aegis as they don't know how to use the primary.
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwv-transform", // yes I know it's not out yet, but I might as well in order to get ahead.
+    "value": {
+      "minRange": 4,
+      "maxRange": 30,
+      "forceMoveRange": 25
+    }
+  },
+  // Skipping Nautilus, pointless.
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwovercharge", // yes I know it's not out yet, but I might as well in order to get ahead.
+    "value": {
+      "minRange": 5,
+      "maxRange": 25,
+      "forceMoveRange": 20
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwsarin", 
+    "value": {
+      "minRange": 0.5,
+      "maxRange": 3
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwrapture", 
+    "value": {
+      "minRange": 1.5,
+      "maxRange": 5.5
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwsamuraiheart", 
+    "value": {
+      "minRange": 1,
+      "maxRange": 6
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwfear", // They don't know how to pull it back all the way so reduced range.
+    "value": {
+      "minRange": 10,
+      "maxRange": 25,
+      "forceMoveRange": 22
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwomniathrower", 
+    "value": {
+      "minRange": 10,
+      "maxRange": 20,
+      "forceMoveRange": 15
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwsiphonpurge", 
+    "value": {
+      "minRange": 0.5,
+      "maxRange": 2.5
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwepimetheus",
+    "value": {
+      "minRange": 10,
+      "maxRange": 30,
+      "forceMoveRange": 25
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwheadhunter",
+    "value": {
+      "minRange": 25,
+      "maxRange": 55,
+      "forceMoveRange": 50
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwgungnir", 
+    "value": {
+      "minRange": 3.5,
+      "maxRange": 7
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwdangerclose",
+    "value": {
+      "minRange": 3,
+      "maxRange": 15,
+      "forceMoveRange": 12
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwanne",
+    "value": {
+      "minRange": 5,
+      "maxRange": 25,
+      "forceMoveRange": 20
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgwmarie",
+    "value": {
+      "minRange": 5,
+      "maxRange": 25,
+      "forceMoveRange": 20
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwnomadicsoul", 
+    "value": {
+      "minRange": 1,
+      "maxRange": 4.5
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ivrpgworbital",
+    "value": {
+      "minRange": 7,
+      "maxRange": 28,
+      "forceMoveRange": 25
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgwsoullesswhisper", 
+    "value": {
+      "minRange": 0.5,
+      "maxRange": 2.5
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/ivrpgw_eldnir", 
+    "value": {
+      "minRange": 3,
+      "maxRange": 8
+    }
+  }
+]


### PR DESCRIPTION
* Adepts, Alchemists, Elementress, Paladin, and Technomancers enable batons
* Specializations that increase wand damage also increase Baton damage.
* Battlemages and Warlocks do not allow usage of Saturn Batons.
* Elementress can use the Nova/SuperNova/PrimedNova (Because a specialization should not ban your class weapon)