### PR TITLE
Elementress Primary Ability Bug

### DIFF
--- a/ivrpg_specs/techs/elementress/attune.lua
+++ b/ivrpg_specs/techs/elementress/attune.lua
@@ -262,9 +262,9 @@ function aimDirection(inaccuracy)
 end
   
 -- Check if the Primary Projectile can be fired.
-function action1(skipCheck)
-  if (self.cooldownTimer > 0 or self.active) or ((not skipCheck)
-    and world.entityHandItem(self.id, "primary"))
+function action1()
+  if (self.cooldownTimer > 0 or self.active) or 
+    world.entityHandItem(self.id, "primary")
     or status.statPositive("activeMovementAbilities") then return end
     if self.shiftHeld and self.cooldownTimerU == 0 and self.percentList[self.elementMod] >= 15 then
       -- If statement to check if element is Fire and Ultimate is used. Don't want to go through walls.


### PR DESCRIPTION
The Elementress's Primary ability will always fire regardless of what the player is holding. I don't think this is the expected behavior, but feel free to let me know if this is not the case. This PR addresses this issue.

- Removed `skipCheck` parameter from `action1()` in `attune.lua`